### PR TITLE
Update Home navigation links to new /home route

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -106,7 +106,7 @@ const Header = () => {
             {/* Desktop Navigation */}
             <nav className="nav desktop-nav" aria-label="Main Navigation">
                 <ul className="nav__list">
-                    <li className="nav__item"><Link to="/">Home</Link></li>
+                    <li className="nav__item"><Link to="/home">Home</Link></li>
                     <li className="nav__item"><Link to="/about">About</Link></li>
                     <li className="nav__item"><Link to="/blog">Blog</Link></li>
                     <li className="nav__item"><Link to="/add-essay">Add Essay</Link></li>
@@ -135,7 +135,7 @@ const Header = () => {
                 ref={mobileNavRef}
             >
                 <ul className="nav__list">
-                    <li className="nav__item"><Link to="/" onClick={closeMobileMenu}>Home</Link></li>
+                    <li className="nav__item"><Link to="/home" onClick={closeMobileMenu}>Home</Link></li>
                     <li className="nav__item"><Link to="/about" onClick={closeMobileMenu}>About</Link></li>
                     <li className="nav__item"><Link to="/blog" onClick={closeMobileMenu}>Blog</Link></li>
                     <li className="nav__item"><Link to="/add-essay" onClick={closeMobileMenu}>Add Essay</Link></li>


### PR DESCRIPTION
## Summary
- update desktop and mobile "Home" links to point to `/home`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `curl http://localhost:5000/home | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_68bfcdbfbde88320b387564345280866