### PR TITLE
feat: add text prop to NeonTextEffect

### DIFF
--- a/src/components/NeonTextEffect.js
+++ b/src/components/NeonTextEffect.js
@@ -1,8 +1,13 @@
 import React from "react";
+import PropTypes from "prop-types";
 import "./NeonTextEffect.css";
 
-const NeonTextEffect = () => {
-    return <h1 className="neon-text">Chongshen Yang</h1>;
+const NeonTextEffect = ({ text = "" }) => {
+    return <h1 className="neon-text">{text}</h1>;
+};
+
+NeonTextEffect.propTypes = {
+    text: PropTypes.string,
 };
 
 export default NeonTextEffect;


### PR DESCRIPTION
## Summary
- allow NeonTextEffect to render dynamic `text` prop
- add PropTypes validation

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfcdc2a9608320ac9fab26c0cd5ae4