### PR TITLE
Handle addPost errors with inline feedback

### DIFF
--- a/src/pages/AddEssay.css
+++ b/src/pages/AddEssay.css
@@ -168,3 +168,15 @@ label {
             0 0 20px rgba(58, 207, 213, 0.6);
     margin-bottom: 30px;
 }
+
+.success-message {
+    color: #3acfd5;
+    margin-top: 10px;
+    text-align: center;
+}
+
+.error-message {
+    color: #ff4d4d;
+    margin-top: 10px;
+    text-align: center;
+}

--- a/src/pages/AddEssay.js
+++ b/src/pages/AddEssay.js
@@ -7,13 +7,21 @@ import './AddEssay.css';
 const AddEssay = () => {
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
+    const [successMessage, setSuccessMessage] = useState('');
+    const [errorMessage, setErrorMessage] = useState('');
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        await addPost(title, content); // Submit the title and markdown content
-        setTitle('');
-        setContent('');
-        alert('Essay added successfully!');
+        setSuccessMessage('');
+        setErrorMessage('');
+        try {
+            await addPost(title, content); // Submit the title and markdown content
+            setTitle('');
+            setContent('');
+            setSuccessMessage('Essay added successfully!');
+        } catch (error) {
+            setErrorMessage('Failed to add essay. Please try again.');
+        }
     };
 
     return (
@@ -47,6 +55,8 @@ const AddEssay = () => {
                 <button type="submit" className="btn-submit">
                     Submit
                 </button>
+                {successMessage && <p className="success-message">{successMessage}</p>}
+                {errorMessage && <p className="error-message">{errorMessage}</p>}
             </form>
         </div>
 


### PR DESCRIPTION
## Summary
- wrap addPost submission in a try/catch to gracefully handle failures
- show inline success and error messages instead of blocking alert dialogs
- style success and error messages for visibility

## Testing
- `npm test -- --watchAll=false` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfcdc4a8e083209995a214a842f361