### PR TITLE
feat: add projects page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import Header from './components/Header';
 import Footer from './components/Footer';
 import Starfield from './components/StarField';
 import Life from './pages/Life';
+import Projects from './pages/Projects';
 import './App.css';
 
 const App = () => {
@@ -26,6 +27,7 @@ const App = () => {
                         <Route path="/about" element={<About />} />
                         <Route path="/blog" element={<Blog />} />
                         <Route path="/add-essay" element={<AddEssay />} />
+                        <Route path="/projects" element={<Projects />} />
                         <Route path="/life" element={<Life />} />
                         {/* Fallback for undefined routes */}
                         <Route path="*" element={<Navigate to="/about" replace />} />

--- a/src/pages/Projects.css
+++ b/src/pages/Projects.css
@@ -1,0 +1,47 @@
+.projects-section {
+    margin: 60px auto;
+    max-width: 1000px;
+    padding: 0 20px;
+}
+
+.projects-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+    gap: 20px;
+}
+
+.project-grid-item {
+    background: linear-gradient(to bottom, #1a1a40, #2d2d60);
+    padding: 20px;
+    border-radius: 8px;
+    text-align: left;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.3);
+}
+
+.project-grid-item:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 6px 20px rgba(58, 207, 213, 0.5);
+}
+
+.project-title {
+    font-size: 1.4rem;
+    color: #9a7df8;
+    margin-bottom: 10px;
+    text-shadow: 0 0 8px rgba(154, 125, 248, 0.3);
+}
+
+.project-description {
+    font-size: 1rem;
+    line-height: 1.5;
+    margin-bottom: 15px;
+}
+
+.project-link {
+    color: #9a7df8;
+    text-decoration: none;
+}
+
+.project-link:hover {
+    text-decoration: underline;
+}

--- a/src/pages/Projects.js
+++ b/src/pages/Projects.js
@@ -1,0 +1,46 @@
+import React from "react";
+import "./Projects.css";
+
+const projectsData = [
+    {
+        title: "Semi-Supervised Learning Techniques Under Label Scarcity",
+        description:
+            "Investigates semi-supervised learning methods when labeled data is limited, comparing self-training, co-training, ensembles, and unsupervised pretraining against a supervised baseline.",
+        link: "",
+    },
+    {
+        title: "The Minimax Algorithm and Strategic Decision-Making",
+        description:
+            "Explores the Minimax algorithm for optimal play in two-player games, detailing alpha-beta pruning and applications across AI, economics, and cybersecurity.",
+        link: "",
+    },
+];
+
+const Projects = () => {
+    return (
+        <div className="projects-section">
+            <h2>Projects</h2>
+            <div className="projects-grid">
+                {projectsData.map((project, index) => (
+                    <div key={index} className="project-grid-item">
+                        <h3 className="project-title">{project.title}</h3>
+                        <p className="project-description">{project.description}</p>
+                        {project.link && (
+                            <a
+                                href={project.link}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="project-link"
+                            >
+                                Learn More
+                            </a>
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default Projects;
+


### PR DESCRIPTION
## Summary
- add dedicated Projects page and style sheet
- wire Projects route into app routing

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfcdc138648320ba905d48dda61842