### PR TITLE
feat: configure environment variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+REACT_APP_API_URL=http://localhost:5001/api
+PORT=5001
+CLIENT_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Environment Variables
+
+The application uses a `.env` file to configure runtime values.
+
+```
+REACT_APP_API_URL=http://localhost:5001/api
+PORT=5001
+CLIENT_URL=http://localhost:3000
+```
+
+- `REACT_APP_API_URL` sets the base URL for API requests in the React app.
+- `PORT` specifies the port for the Express server.
+- `CLIENT_URL` defines the origin allowed by the server's CORS configuration.
+
+Set these values as needed before running or deploying the app.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "axios": "^1.7.9",
         "cors": "^2.8.5",
         "cra-template": "1.2.0",
+        "dotenv": "^17.2.2",
         "express": "^4.21.2",
         "focus-trap-react": "^11.0.1",
         "nodeman": "^1.1.2",
@@ -7074,12 +7075,15 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
-      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
       "license": "BSD-2-Clause",
       "engines": {
-        "node": ">=10"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dotenv-expand": {
@@ -15226,6 +15230,15 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-scripts/node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/react-simplemde-editor": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "axios": "^1.7.9",
     "cors": "^2.8.5",
     "cra-template": "1.2.0",
+    "dotenv": "^17.2.2",
     "express": "^4.21.2",
     "focus-trap-react": "^11.0.1",
     "nodeman": "^1.1.2",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const fs = require('fs');
 const path = require('path');
+require('dotenv').config();
 
 const app = express();
 
@@ -9,7 +10,7 @@ app.use(express.json());
 
 app.use(
     cors({
-        origin: 'http://localhost:3000',
+        origin: process.env.CLIENT_URL || 'http://localhost:3000',
         methods: ['GET', 'POST'],
         credentials: true,
     })
@@ -80,7 +81,7 @@ app.use((err, req, res, next) => {
     res.status(500).json({ error: 'Something went wrong. Please try again later.' });
 });
 
-const PORT = 5001;
+const PORT = process.env.PORT || 5001;
 app.listen(PORT, () => {
     console.log(`Server is running on http://localhost:${PORT}`);
 });

--- a/src/utils/utils.js
+++ b/src/utils/utils.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 
-// Base API URL
-const API_URL = 'http://localhost:5001/api';
+// Base API URL, configurable via environment variable
+const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5001/api';
 
 // Axios instance for reusable configuration
 const apiClient = axios.create({


### PR DESCRIPTION
## Summary
- load environment variables from new `.env` file
- use environment variables for API URL and server port
- document environment variable usage

## Testing
- `npm test -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bfcdc3f9c48320a3a9bd0830487122